### PR TITLE
Allow any PHP versions equal to or greater than PHP 7.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,9 +3,9 @@
     "license": "Apache-2.0",
     "type": "magento2-module",
     "description": "Magento 2 Afterpay Payment Module",
-    "version": "5.0.0",
+    "version": "5.0.1",
     "require": {
-        "php": "~7.4.0||~8.0.0",
+        "php": ">=7.4",
         "magento/framework": "^103.0",
         "magento/module-checkout": "100.4.*",
         "magento/module-payment": "100.4.*",


### PR DESCRIPTION
Haven't bumped the major/minor versions as technically this shouldn't be backwards incompatible.