### PR TITLE
Prevent error being thrown for no store categories

### DIFF
--- a/Model/Config/Source/Category.php
+++ b/Model/Config/Source/Category.php
@@ -49,6 +49,10 @@ class Category implements \Magento\Framework\Data\OptionSourceInterface
         $categories = $this->categoryHelper->getStoreCategories(false, true);
         $this->storeManager->setCurrentStore($currentStoreId);
 
+        if (empty($categories->getItems())) {
+            return [];
+        }
+
         return $this->convertToTree($categories);
     }
 


### PR DESCRIPTION
Some websites may be setting up their payment methods for live testing before categories are set up :shrug: 